### PR TITLE
Django 1.8+ compatibility

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -19,6 +19,10 @@ A fork of (a fork of) django-backup which adds:
 
 Run `pip install django-icybackup-jl`, then add `icybackup` to your `INSTALLED_APPS`.
 
+### Django compatibility
+- For Django < 1.8, use `django-icybackup-jl` version of 0.1.6 (or lower)
+- For Django >= 1.8, use `django-icybackup-jl` version 0.1.8 (or higher)
+
 ## Usage
 
 ### Backing up
@@ -72,6 +76,7 @@ The following people contributed code to this project or its ancestors, in chron
 - Yar Kravtsov
 - Adam Brenecki, St Barnabas' Theological College
 - Jaroslaw Lachowski
+- Adrian Bohdanowicz
 
 ## License
 

--- a/README.mdown
+++ b/README.mdown
@@ -20,7 +20,7 @@ A fork of (a fork of) django-backup which adds:
 Run `pip install django-icybackup-jl`, then add `icybackup` to your `INSTALLED_APPS`.
 
 ### Django compatibility
-- For Django < 1.8, use `django-icybackup-jl` version of 0.1.6 (or lower)
+- For Django < 1.8, use `django-icybackup-jl` version 0.1.6 (or lower)
 - For Django >= 1.8, use `django-icybackup-jl` version 0.1.8 (or higher)
 
 ## Usage

--- a/icybackup/__init__.py
+++ b/icybackup/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "0.1.7"
+__version__ = "0.1.8"

--- a/icybackup/__init__.py
+++ b/icybackup/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/icybackup/management/commands/backup.py
+++ b/icybackup/management/commands/backup.py
@@ -26,28 +26,54 @@ sys.setdefaultencoding('utf-8')
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option(
-            '-o', '--output', default=None, dest='output',
-            help='Write backup to file'),
-        make_option(
-            '-d', '--outdir', default=None, dest='outdir',
-            help='Write backup to timestamped file in a directory'),
-        make_option(
-            '-g', '--glacier', default=None, dest='glacier',
-            help='Upload backup to the Amazon Glacier vault with the given ARN'),
-        make_option(
-            '-O', '--stdout', action='store_true', dest='stdout',
-            help='Output backup tarball to standard output'),
-        make_option(
-            '--extra', '-e', action='append', default=[], dest='extras',
-            help='Include extra directories or files in the backup tarball'),
-        make_option(
-            '-n', '--native-django-dump', action='store_true', default=None,
-            dest='nativedump', help='use django build in database dump method'),
-    )
 
     help = "Back up a Django installation (database and media directory)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-o',
+            '--output',
+            default=None,
+            dest='output',
+            help='Write backup to file'
+        )
+        parser.add_argument(
+            '-d',
+            '--outdir',
+            default=None,
+            dest='outdir',
+            help='Write backup to timestamped file in a directory'
+        )
+        parser.add_argument(
+            '-g',
+            '--glacier',
+            default=None,
+            dest='glacier',
+            help='Upload backup to the Amazon Glacier vault with the given ARN'
+        )
+        parser.add_argument(
+            '-O',
+            '--stdout',
+            dest='stdout',
+            action='store_true',
+            help='Output backup tarball to standard output'
+        )
+        parser.add_argument(
+            '-e',
+            '--extra',
+            default=[],
+            dest='extras',
+            action='append',
+            help='Include extra directories or files in the backup tarball'
+        )
+        parser.add_argument(
+            '-n',
+            '--native-django-dump',
+            default=None,
+            dest='nativedump',
+            action='store_true',
+            help='Use django build in database dump method'
+        )
 
     def handle(self, *args, **options):
         extras = options.get('extras')

--- a/icybackup/management/commands/restore.py
+++ b/icybackup/management/commands/restore.py
@@ -27,21 +27,38 @@ sys.setdefaultencoding('utf-8')
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option(
-            '-i', '--file', default=None, dest='input',
-            help='Read backup from file'),
-        make_option(
-            '--pg-restore-flags', default=None, dest='postgres_flags',
-            help='Flags to pass to pg_restore'),
-        make_option(
-            '-I', '--stdin', action='store_true', dest='stdin',
-            help='Read backup from standard input'),
-        make_option(
-            '-n', '--native-django-restore', action='store_true', default=None,
-            dest='nativerestore', help='use django build in load data method'),
-        )
+
     help = "Restore a Django installation (database and media directory)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-i',
+            '--file',
+            default=None,
+            dest='input',
+            help='Read backup from file'
+        )
+        parser.add_argument(
+            '--pg-restore-flags',
+            default=None,
+            dest='postgres_flags',
+            help='Flags to pass to pg_restore'
+        )
+        parser.add_argument(
+            '-I',
+            '--stdin',
+            dest='stdin',
+            action='store_true',
+            help='Read backup from standard input'
+        )
+        parser.add_argument(
+            '-n',
+            '--native-django-restore',
+            default=None,
+            dest='nativerestore',
+            action='store_true',
+            help='Use django build in load data method'
+        )
 
     def handle(self, *args, **options):
         input_file = options.get('input')


### PR DESCRIPTION
As django 1.8 moves from optparse to argparse, necessary changes to command line commands were added. Also a respective info of the module version with django version compatibility was added. The module version updated to better fit django compatibility.